### PR TITLE
HI-65 basic GeoIp role

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,13 @@ geoip_packages:
 
 geoip_databases: GeoLite2-Country
 geoip_user: "{{ ansible_ssh_user }}"
+geoip_group: "{{ ansible_ssh_user }}"
 geoip_config_location: "/home/{{ geoip_user }}/GeoIp.conf"
 ```
+
+Few notes:
+0. geoip_databases is a string, if more databses are required, it is still a string - "GeoLite2-Country GeoLite2-City" (See docs noted above)
+0. geoip_user needs to be a system user with a home directory
 
 ----------------
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,22 @@
 geoip Role
 =========
 
+This role installs the `geoipupdate` tool which installs the configured geoip databases. It also installs required packages to use geoip with nginx.
+It is recommended to run geoipupdate via a cron task. See the docs - https://dev.maxmind.com/geoip/geoipupdate/
 
 Role Variables
 --------------
 
 ```
-# Any Vars?
+geoip_packages:
+  - libmaxminddb0
+  - libmaxminddb-dev
+  - mmdb-bin
+  - geoipupdate
+
+geoip_databases: GeoLite2-Country
+geoip_user: "{{ ansible_ssh_user }}"
+geoip_config_location: "/home/{{ geoip_user }}/GeoIp.conf"
 ```
 
 ----------------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,0 +1,11 @@
+---
+
+geoip_packages:
+  - libmaxminddb0
+  - libmaxminddb-dev
+  - mmdb-bin
+  - geoipupdate
+
+geoip_databases: GeoLite2-Country
+geoip_user: "{{ ansible_ssh_user }}"
+geoip_config_location: "/home/{{ geoip_user }}/GeoIp.conf"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,4 +8,5 @@ geoip_packages:
 
 geoip_databases: GeoLite2-Country
 geoip_user: "{{ ansible_ssh_user }}"
+geoip_group: "{{ ansible_ssh_user }}"
 geoip_config_location: "/home/{{ geoip_user }}/GeoIp.conf"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,2 +1,42 @@
 ---
 
+- name: Add MaxMind PPA
+  become: yes
+  apt_repository:
+    repo: ppa:maxmind/ppa
+    update_cache: yes
+  tags:
+  - geoip
+
+- name: Ensure GeoIp packages are installed
+  become: yes
+  apt:
+    name: "{{ item }}"
+    state: present
+  with_items: "{{ geoip_packages }}"
+  tags:
+    - geoip
+
+- name: Configure GeoIp
+  template:
+    src: templates/GeoIp.conf.j2
+    dest: "{{ geoip_config_location }}"
+  tags:
+    - geoip
+
+- name: Ensure permissions on GeoIp Database locations
+  become: yes
+  file:
+    path: /usr/share/GeoIP
+    owner: "{{ geoip_user }}"
+    group: "{{ geoip_user }}"
+    state: directory
+    recurse: yes
+  tags:
+    - geoip
+
+- name: Update GeoIp Databases
+  shell: "ls"
+  tags:
+    - geoip
+    - geoip-db-update

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -29,7 +29,7 @@
   file:
     path: /usr/share/GeoIP
     owner: "{{ geoip_user }}"
-    group: "{{ geoip_user }}"
+    group: "{{ geoip_group }}"
     state: directory
     recurse: yes
   tags:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -36,7 +36,8 @@
     - geoip
 
 - name: Update GeoIp Databases
-  shell: "ls"
+  shell: "geoipupdate -f {{ geoip_config_location }}"
+  changed_when: false
   tags:
     - geoip
     - geoip-db-update

--- a/templates/GeoIp.conf.j2
+++ b/templates/GeoIp.conf.j2
@@ -1,0 +1,42 @@
+# {{ ansible_managed }}
+
+# Please see https://dev.maxmind.com/geoip/geoipupdate/ for instructions
+# on setting up geoipupdate, including information on how to download a
+# pre-filled GeoIP.conf file.
+
+# Enter your account ID and license key below. These are available from
+# https://www.maxmind.com/en/my_license_key. If you are only using free
+# GeoLite databases, do not uncomment these lines.
+# TODO - support paid accounts
+#AccountID 126925
+#LicenseKey 7TW6XkirBdOR
+
+# Enter the edition IDs of the databases you would like to update.
+# Multiple edition IDs are separated by spaces.
+EditionIDs {{ geoip_databases }}
+
+# The remaining settings are OPTIONAL.
+
+# The directory to store the database files. Defaults to /usr/share/GeoIP
+# DatabaseDirectory /usr/share/GeoIP
+
+# The server to use. Defaults to "updates.maxmind.com".
+# Host updates.maxmind.com
+
+# The proxy host name or IP address. You may optionally specify a
+# port number, e.g., 127.0.0.1:8888. If no port number is specified, 1080
+# will be used.
+# Proxy 127.0.0.1:8888
+
+# The user name and password to use with your proxy server.
+# ProxyUserPassword username:password
+
+# Whether to preserve modification times of files downloaded from the server.
+# Defaults to "0".
+# PreserveFileTimes 0
+
+# The lock file to use. This ensures only one geoipupdate process can run at a
+# time.
+# Note: Once created, this lockfile is not removed from the filesystem.
+# Defaults to ".geoipupdate.lock" under the DatabaseDirectory.
+# LockFile /usr/share/GeoIP/.geoipupdate.lock


### PR DESCRIPTION
This PR will:

- install the `geoipupdate` tool, do some basic configuration, and run it to install the geoip databases
- install required packages required for this [nginx](https://github.com/leev/ngx_http_geoip2_module) module